### PR TITLE
Cartfile: set grpc-swift to a fixed commit before release 0.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "grpc/grpc-swift" "master"
+github "grpc/grpc-swift" "23a0ebdee9613f615f2f2469ed3e700df5856417"
 github "ReactiveX/RxSwift" ~> 4.0
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.2.5
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.2.6


### PR DESCRIPTION
We don't want our clients to rely on the "master" version of grpc-swift, but they haven't released since we added carthage support there.