### PR TITLE
Carthage: automatically update patches

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "grpc/grpc-swift" "23a0ebdee9613f615f2f2469ed3e700df5856417"
 github "ReactiveX/RxSwift" ~> 4.0
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.2.7
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" ~> 0.2.7


### PR DESCRIPTION
Use "compatible versions" of backend (in the Cartfile) for somehow automated updates. When running `carthage update ...`, it should take the latest binary compatible with (here) 0.2.7, which at the moment is 0.2.8.

Note that 0.3.0 is not compatible with 0.2.7, so it will require an update in the Cartfile.