### PR TITLE
Move back to grpc-swift upstream (release 0.8.0)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "3drobotics/grpc-swift" "master"
+github "grpc/grpc-swift" ~> 0.8.0
 github "ReactiveX/RxSwift" ~> 4.0
 binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" ~> 0.14.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.14.2"
-github "3drobotics/grpc-swift" "b7659e1031b441da2db60fa879e8157799730f02"
-github "ReactiveX/RxSwift" "4.4.1"
+github "ReactiveX/RxSwift" "4.4.2"
+github "grpc/grpc-swift" "0.8.0"

--- a/Sources/Dronecode-SDK-Swift/Generated/action.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/action.grpc.swift
@@ -119,246 +119,384 @@ fileprivate final class DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAl
 /// Instantiate DronecodeSdk_Rpc_Action_ActionServiceServiceClient, then call methods of this protocol to make API calls.
 internal protocol DronecodeSdk_Rpc_Action_ActionServiceService: ServiceClient {
   /// Synchronous. Unary.
-  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest) throws -> DronecodeSdk_Rpc_Action_ArmResponse
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ArmResponse
   /// Asynchronous. Unary.
-  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall
 
   /// Synchronous. Unary.
-  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest) throws -> DronecodeSdk_Rpc_Action_DisarmResponse
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_DisarmResponse
   /// Asynchronous. Unary.
-  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall
 
   /// Synchronous. Unary.
-  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse
   /// Asynchronous. Unary.
-  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall
 
   /// Synchronous. Unary.
-  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest) throws -> DronecodeSdk_Rpc_Action_LandResponse
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_LandResponse
   /// Asynchronous. Unary.
-  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall
 
   /// Synchronous. Unary.
-  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest) throws -> DronecodeSdk_Rpc_Action_RebootResponse
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_RebootResponse
   /// Asynchronous. Unary.
-  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall
 
   /// Synchronous. Unary.
-  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest) throws -> DronecodeSdk_Rpc_Action_KillResponse
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_KillResponse
   /// Asynchronous. Unary.
-  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall
 
   /// Synchronous. Unary.
-  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse
   /// Asynchronous. Unary.
-  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall
 
   /// Synchronous. Unary.
-  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse
   /// Asynchronous. Unary.
-  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall
 
   /// Synchronous. Unary.
-  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse
   /// Asynchronous. Unary.
-  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall
 
   /// Synchronous. Unary.
-  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse
   /// Asynchronous. Unary.
-  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall
 
   /// Synchronous. Unary.
-  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse
   /// Asynchronous. Unary.
-  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall
 
   /// Synchronous. Unary.
-  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse
   /// Asynchronous. Unary.
-  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall
 
   /// Synchronous. Unary.
-  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse
   /// Asynchronous. Unary.
-  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall
 
   /// Synchronous. Unary.
-  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse
   /// Asynchronous. Unary.
-  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall
 
   /// Synchronous. Unary.
-  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse
   /// Asynchronous. Unary.
-  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Action_ActionServiceService {
+  /// Synchronous. Unary.
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest) throws -> DronecodeSdk_Rpc_Action_ArmResponse {
+    return try self.arm(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall {
+    return try self.arm(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest) throws -> DronecodeSdk_Rpc_Action_DisarmResponse {
+    return try self.disarm(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall {
+    return try self.disarm(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse {
+    return try self.takeoff(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall {
+    return try self.takeoff(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest) throws -> DronecodeSdk_Rpc_Action_LandResponse {
+    return try self.land(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall {
+    return try self.land(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest) throws -> DronecodeSdk_Rpc_Action_RebootResponse {
+    return try self.reboot(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall {
+    return try self.reboot(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest) throws -> DronecodeSdk_Rpc_Action_KillResponse {
+    return try self.kill(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall {
+    return try self.kill(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse {
+    return try self.returnToLaunch(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall {
+    return try self.returnToLaunch(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse {
+    return try self.transitionToFixedWing(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall {
+    return try self.transitionToFixedWing(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse {
+    return try self.transitionToMulticopter(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall {
+    return try self.transitionToMulticopter(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse {
+    return try self.getTakeoffAltitude(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall {
+    return try self.getTakeoffAltitude(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse {
+    return try self.setTakeoffAltitude(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall {
+    return try self.setTakeoffAltitude(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse {
+    return try self.getMaximumSpeed(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall {
+    return try self.getMaximumSpeed(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse {
+    return try self.setMaximumSpeed(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall {
+    return try self.setMaximumSpeed(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse {
+    return try self.getReturnToLaunchAltitude(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall {
+    return try self.getReturnToLaunchAltitude(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse {
+    return try self.setReturnToLaunchAltitude(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall {
+    return try self.setReturnToLaunchAltitude(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
 internal final class DronecodeSdk_Rpc_Action_ActionServiceServiceClient: ServiceClientBase, DronecodeSdk_Rpc_Action_ActionServiceService {
   /// Synchronous. Unary.
-  internal func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest) throws -> DronecodeSdk_Rpc_Action_ArmResponse {
+  internal func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ArmResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceArmCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall {
+  internal func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceArmCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest) throws -> DronecodeSdk_Rpc_Action_DisarmResponse {
+  internal func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_DisarmResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceDisarmCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall {
+  internal func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceDisarmCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse {
+  internal func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceTakeoffCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall {
+  internal func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceTakeoffCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func land(_ request: DronecodeSdk_Rpc_Action_LandRequest) throws -> DronecodeSdk_Rpc_Action_LandResponse {
+  internal func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_LandResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceLandCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall {
+  internal func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceLandCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest) throws -> DronecodeSdk_Rpc_Action_RebootResponse {
+  internal func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_RebootResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceRebootCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall {
+  internal func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceRebootCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest) throws -> DronecodeSdk_Rpc_Action_KillResponse {
+  internal func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_KillResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceKillCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall {
+  internal func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceKillCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse {
+  internal func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall {
+  internal func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse {
+  internal func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall {
+  internal func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse {
+  internal func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall {
+  internal func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse {
+  internal func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall {
+  internal func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse {
+  internal func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall {
+  internal func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse {
+  internal func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall {
+  internal func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse {
+  internal func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall {
+  internal func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse {
+  internal func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall {
+  internal func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse {
+  internal func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall {
+  internal func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall {
     return try DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -366,166 +504,166 @@ internal final class DronecodeSdk_Rpc_Action_ActionServiceServiceClient: Service
 class DronecodeSdk_Rpc_Action_ActionServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Action_ActionServiceService {
   var armRequests: [DronecodeSdk_Rpc_Action_ArmRequest] = []
   var armResponses: [DronecodeSdk_Rpc_Action_ArmResponse] = []
-  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest) throws -> DronecodeSdk_Rpc_Action_ArmResponse {
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ArmResponse {
     armRequests.append(request)
     defer { armResponses.removeFirst() }
     return armResponses.first!
   }
-  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall {
+  func arm(_ request: DronecodeSdk_Rpc_Action_ArmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ArmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceArmCall {
     fatalError("not implemented")
   }
 
   var disarmRequests: [DronecodeSdk_Rpc_Action_DisarmRequest] = []
   var disarmResponses: [DronecodeSdk_Rpc_Action_DisarmResponse] = []
-  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest) throws -> DronecodeSdk_Rpc_Action_DisarmResponse {
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_DisarmResponse {
     disarmRequests.append(request)
     defer { disarmResponses.removeFirst() }
     return disarmResponses.first!
   }
-  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall {
+  func disarm(_ request: DronecodeSdk_Rpc_Action_DisarmRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_DisarmResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceDisarmCall {
     fatalError("not implemented")
   }
 
   var takeoffRequests: [DronecodeSdk_Rpc_Action_TakeoffRequest] = []
   var takeoffResponses: [DronecodeSdk_Rpc_Action_TakeoffResponse] = []
-  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse {
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TakeoffResponse {
     takeoffRequests.append(request)
     defer { takeoffResponses.removeFirst() }
     return takeoffResponses.first!
   }
-  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall {
+  func takeoff(_ request: DronecodeSdk_Rpc_Action_TakeoffRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TakeoffResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTakeoffCall {
     fatalError("not implemented")
   }
 
   var landRequests: [DronecodeSdk_Rpc_Action_LandRequest] = []
   var landResponses: [DronecodeSdk_Rpc_Action_LandResponse] = []
-  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest) throws -> DronecodeSdk_Rpc_Action_LandResponse {
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_LandResponse {
     landRequests.append(request)
     defer { landResponses.removeFirst() }
     return landResponses.first!
   }
-  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall {
+  func land(_ request: DronecodeSdk_Rpc_Action_LandRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_LandResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceLandCall {
     fatalError("not implemented")
   }
 
   var rebootRequests: [DronecodeSdk_Rpc_Action_RebootRequest] = []
   var rebootResponses: [DronecodeSdk_Rpc_Action_RebootResponse] = []
-  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest) throws -> DronecodeSdk_Rpc_Action_RebootResponse {
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_RebootResponse {
     rebootRequests.append(request)
     defer { rebootResponses.removeFirst() }
     return rebootResponses.first!
   }
-  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall {
+  func reboot(_ request: DronecodeSdk_Rpc_Action_RebootRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_RebootResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceRebootCall {
     fatalError("not implemented")
   }
 
   var killRequests: [DronecodeSdk_Rpc_Action_KillRequest] = []
   var killResponses: [DronecodeSdk_Rpc_Action_KillResponse] = []
-  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest) throws -> DronecodeSdk_Rpc_Action_KillResponse {
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_KillResponse {
     killRequests.append(request)
     defer { killResponses.removeFirst() }
     return killResponses.first!
   }
-  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall {
+  func kill(_ request: DronecodeSdk_Rpc_Action_KillRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_KillResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceKillCall {
     fatalError("not implemented")
   }
 
   var returnToLaunchRequests: [DronecodeSdk_Rpc_Action_ReturnToLaunchRequest] = []
   var returnToLaunchResponses: [DronecodeSdk_Rpc_Action_ReturnToLaunchResponse] = []
-  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse {
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_ReturnToLaunchResponse {
     returnToLaunchRequests.append(request)
     defer { returnToLaunchResponses.removeFirst() }
     return returnToLaunchResponses.first!
   }
-  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall {
+  func returnToLaunch(_ request: DronecodeSdk_Rpc_Action_ReturnToLaunchRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_ReturnToLaunchResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceReturnToLaunchCall {
     fatalError("not implemented")
   }
 
   var transitionToFixedWingRequests: [DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest] = []
   var transitionToFixedWingResponses: [DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse] = []
-  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse {
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse {
     transitionToFixedWingRequests.append(request)
     defer { transitionToFixedWingResponses.removeFirst() }
     return transitionToFixedWingResponses.first!
   }
-  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall {
+  func transitionToFixedWing(_ request: DronecodeSdk_Rpc_Action_TransitionToFixedWingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToFixedWingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToFixedWingCall {
     fatalError("not implemented")
   }
 
   var transitionToMulticopterRequests: [DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest] = []
   var transitionToMulticopterResponses: [DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse] = []
-  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse {
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse {
     transitionToMulticopterRequests.append(request)
     defer { transitionToMulticopterResponses.removeFirst() }
     return transitionToMulticopterResponses.first!
   }
-  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall {
+  func transitionToMulticopter(_ request: DronecodeSdk_Rpc_Action_TransitionToMulticopterRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_TransitionToMulticopterResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceTransitionToMulticopterCall {
     fatalError("not implemented")
   }
 
   var getTakeoffAltitudeRequests: [DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest] = []
   var getTakeoffAltitudeResponses: [DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse] = []
-  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse {
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse {
     getTakeoffAltitudeRequests.append(request)
     defer { getTakeoffAltitudeResponses.removeFirst() }
     return getTakeoffAltitudeResponses.first!
   }
-  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall {
+  func getTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_GetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetTakeoffAltitudeCall {
     fatalError("not implemented")
   }
 
   var setTakeoffAltitudeRequests: [DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest] = []
   var setTakeoffAltitudeResponses: [DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse] = []
-  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse {
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse {
     setTakeoffAltitudeRequests.append(request)
     defer { setTakeoffAltitudeResponses.removeFirst() }
     return setTakeoffAltitudeResponses.first!
   }
-  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall {
+  func setTakeoffAltitude(_ request: DronecodeSdk_Rpc_Action_SetTakeoffAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetTakeoffAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetTakeoffAltitudeCall {
     fatalError("not implemented")
   }
 
   var getMaximumSpeedRequests: [DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest] = []
   var getMaximumSpeedResponses: [DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse] = []
-  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse {
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse {
     getMaximumSpeedRequests.append(request)
     defer { getMaximumSpeedResponses.removeFirst() }
     return getMaximumSpeedResponses.first!
   }
-  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall {
+  func getMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_GetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetMaximumSpeedCall {
     fatalError("not implemented")
   }
 
   var setMaximumSpeedRequests: [DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest] = []
   var setMaximumSpeedResponses: [DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse] = []
-  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse {
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse {
     setMaximumSpeedRequests.append(request)
     defer { setMaximumSpeedResponses.removeFirst() }
     return setMaximumSpeedResponses.first!
   }
-  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall {
+  func setMaximumSpeed(_ request: DronecodeSdk_Rpc_Action_SetMaximumSpeedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetMaximumSpeedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetMaximumSpeedCall {
     fatalError("not implemented")
   }
 
   var getReturnToLaunchAltitudeRequests: [DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest] = []
   var getReturnToLaunchAltitudeResponses: [DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse] = []
-  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse {
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse {
     getReturnToLaunchAltitudeRequests.append(request)
     defer { getReturnToLaunchAltitudeResponses.removeFirst() }
     return getReturnToLaunchAltitudeResponses.first!
   }
-  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall {
+  func getReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_GetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceGetReturnToLaunchAltitudeCall {
     fatalError("not implemented")
   }
 
   var setReturnToLaunchAltitudeRequests: [DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest] = []
   var setReturnToLaunchAltitudeResponses: [DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse] = []
-  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse {
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse {
     setReturnToLaunchAltitudeRequests.append(request)
     defer { setReturnToLaunchAltitudeResponses.removeFirst() }
     return setReturnToLaunchAltitudeResponses.first!
   }
-  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall {
+  func setReturnToLaunchAltitude(_ request: DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Action_SetReturnToLaunchAltitudeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Action_ActionServiceSetReturnToLaunchAltitudeCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/calibration.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/calibration.grpc.swift
@@ -117,27 +117,59 @@ internal protocol DronecodeSdk_Rpc_Calibration_CalibrationServiceService: Servic
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall
+  func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall
+  func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall
+  func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall
+  func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall
 
   /// Synchronous. Unary.
-  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse
   /// Asynchronous. Unary.
-  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Calibration_CalibrationServiceService {
+  /// Asynchronous. Server-streaming.
+  func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall {
+    return try self.subscribeCalibrateGyro(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall {
+    return try self.subscribeCalibrateAccelerometer(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall {
+    return try self.subscribeCalibrateMagnetometer(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall {
+    return try self.subscribeCalibrateGimbalAccelerometer(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse {
+    return try self.cancel(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall {
+    return try self.cancel(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
@@ -145,44 +177,44 @@ internal final class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceClien
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall {
+  internal func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall {
+  internal func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall {
+  internal func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall {
+  internal func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse {
+  internal func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall {
+  internal func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall {
     return try DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -190,7 +222,7 @@ internal final class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceClien
 class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Calibration_CalibrationServiceService {
   var subscribeCalibrateGyroRequests: [DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest] = []
   var subscribeCalibrateGyroCalls: [DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall] = []
-  func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall {
+  func subscribeCalibrateGyro(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGyroRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGyroCall {
     subscribeCalibrateGyroRequests.append(request)
     defer { subscribeCalibrateGyroCalls.removeFirst() }
     return subscribeCalibrateGyroCalls.first!
@@ -198,7 +230,7 @@ class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceTestStub: ServiceCli
 
   var subscribeCalibrateAccelerometerRequests: [DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest] = []
   var subscribeCalibrateAccelerometerCalls: [DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall] = []
-  func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall {
+  func subscribeCalibrateAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateAccelerometerCall {
     subscribeCalibrateAccelerometerRequests.append(request)
     defer { subscribeCalibrateAccelerometerCalls.removeFirst() }
     return subscribeCalibrateAccelerometerCalls.first!
@@ -206,7 +238,7 @@ class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceTestStub: ServiceCli
 
   var subscribeCalibrateMagnetometerRequests: [DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest] = []
   var subscribeCalibrateMagnetometerCalls: [DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall] = []
-  func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall {
+  func subscribeCalibrateMagnetometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateMagnetometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateMagnetometerCall {
     subscribeCalibrateMagnetometerRequests.append(request)
     defer { subscribeCalibrateMagnetometerCalls.removeFirst() }
     return subscribeCalibrateMagnetometerCalls.first!
@@ -214,7 +246,7 @@ class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceTestStub: ServiceCli
 
   var subscribeCalibrateGimbalAccelerometerRequests: [DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest] = []
   var subscribeCalibrateGimbalAccelerometerCalls: [DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall] = []
-  func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall {
+  func subscribeCalibrateGimbalAccelerometer(_ request: DronecodeSdk_Rpc_Calibration_SubscribeCalibrateGimbalAccelerometerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceSubscribeCalibrateGimbalAccelerometerCall {
     subscribeCalibrateGimbalAccelerometerRequests.append(request)
     defer { subscribeCalibrateGimbalAccelerometerCalls.removeFirst() }
     return subscribeCalibrateGimbalAccelerometerCalls.first!
@@ -222,12 +254,12 @@ class DronecodeSdk_Rpc_Calibration_CalibrationServiceServiceTestStub: ServiceCli
 
   var cancelRequests: [DronecodeSdk_Rpc_Calibration_CancelRequest] = []
   var cancelResponses: [DronecodeSdk_Rpc_Calibration_CancelResponse] = []
-  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse {
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Calibration_CancelResponse {
     cancelRequests.append(request)
     defer { cancelResponses.removeFirst() }
     return cancelResponses.first!
   }
-  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall {
+  func cancel(_ request: DronecodeSdk_Rpc_Calibration_CancelRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Calibration_CancelResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Calibration_CalibrationServiceCancelCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/camera.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/camera.grpc.swift
@@ -209,244 +209,367 @@ fileprivate final class DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCallBase:
 /// Instantiate DronecodeSdk_Rpc_Camera_CameraServiceServiceClient, then call methods of this protocol to make API calls.
 internal protocol DronecodeSdk_Rpc_Camera_CameraServiceService: ServiceClient {
   /// Synchronous. Unary.
-  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse
   /// Asynchronous. Unary.
-  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall
 
   /// Synchronous. Unary.
-  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse
   /// Asynchronous. Unary.
-  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall
 
   /// Synchronous. Unary.
-  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse
   /// Asynchronous. Unary.
-  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall
 
   /// Synchronous. Unary.
-  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse
   /// Asynchronous. Unary.
-  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall
 
   /// Synchronous. Unary.
-  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse
   /// Asynchronous. Unary.
-  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall
 
   /// Synchronous. Unary.
-  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse
   /// Asynchronous. Unary.
-  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall
 
   /// Synchronous. Unary.
-  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse
   /// Asynchronous. Unary.
-  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall
 
   /// Synchronous. Unary.
-  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse
   /// Asynchronous. Unary.
-  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall
+  func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall
 
   /// Synchronous. Unary.
-  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse
   /// Asynchronous. Unary.
-  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall
+  func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall
+  func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall
+  func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall
+  func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall
+  func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall
 
   /// Synchronous. Unary.
-  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse
   /// Asynchronous. Unary.
-  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Camera_CameraServiceService {
+  /// Synchronous. Unary.
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse {
+    return try self.takePhoto(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall {
+    return try self.takePhoto(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse {
+    return try self.startPhotoInterval(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall {
+    return try self.startPhotoInterval(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse {
+    return try self.stopPhotoInterval(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall {
+    return try self.stopPhotoInterval(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse {
+    return try self.startVideo(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall {
+    return try self.startVideo(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse {
+    return try self.stopVideo(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall {
+    return try self.stopVideo(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse {
+    return try self.startVideoStreaming(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall {
+    return try self.startVideoStreaming(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse {
+    return try self.stopVideoStreaming(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall {
+    return try self.stopVideoStreaming(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse {
+    return try self.setMode(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall {
+    return try self.setMode(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall {
+    return try self.subscribeMode(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse {
+    return try self.setVideoStreamSettings(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall {
+    return try self.setVideoStreamSettings(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall {
+    return try self.subscribeVideoStreamInfo(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall {
+    return try self.subscribeCaptureInfo(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall {
+    return try self.subscribeCameraStatus(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall {
+    return try self.subscribeCurrentSettings(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall {
+    return try self.subscribePossibleSettingOptions(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse {
+    return try self.setSetting(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall {
+    return try self.setSetting(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
 internal final class DronecodeSdk_Rpc_Camera_CameraServiceServiceClient: ServiceClientBase, DronecodeSdk_Rpc_Camera_CameraServiceService {
   /// Synchronous. Unary.
-  internal func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse {
+  internal func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall {
+  internal func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse {
+  internal func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall {
+  internal func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse {
+  internal func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall {
+  internal func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse {
+  internal func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall {
+  internal func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse {
+  internal func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall {
+  internal func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse {
+  internal func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall {
+  internal func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse {
+  internal func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall {
+  internal func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse {
+  internal func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetModeCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall {
+  internal func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetModeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall {
+  internal func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse {
+  internal func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall {
+  internal func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall {
+  internal func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall {
+  internal func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall {
+  internal func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall {
+  internal func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall {
+  internal func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse {
+  internal func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall {
+  internal func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall {
     return try DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -454,95 +577,95 @@ internal final class DronecodeSdk_Rpc_Camera_CameraServiceServiceClient: Service
 class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Camera_CameraServiceService {
   var takePhotoRequests: [DronecodeSdk_Rpc_Camera_TakePhotoRequest] = []
   var takePhotoResponses: [DronecodeSdk_Rpc_Camera_TakePhotoResponse] = []
-  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse {
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_TakePhotoResponse {
     takePhotoRequests.append(request)
     defer { takePhotoResponses.removeFirst() }
     return takePhotoResponses.first!
   }
-  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall {
+  func takePhoto(_ request: DronecodeSdk_Rpc_Camera_TakePhotoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_TakePhotoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceTakePhotoCall {
     fatalError("not implemented")
   }
 
   var startPhotoIntervalRequests: [DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest] = []
   var startPhotoIntervalResponses: [DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse] = []
-  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse {
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse {
     startPhotoIntervalRequests.append(request)
     defer { startPhotoIntervalResponses.removeFirst() }
     return startPhotoIntervalResponses.first!
   }
-  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall {
+  func startPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StartPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartPhotoIntervalCall {
     fatalError("not implemented")
   }
 
   var stopPhotoIntervalRequests: [DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest] = []
   var stopPhotoIntervalResponses: [DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse] = []
-  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse {
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse {
     stopPhotoIntervalRequests.append(request)
     defer { stopPhotoIntervalResponses.removeFirst() }
     return stopPhotoIntervalResponses.first!
   }
-  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall {
+  func stopPhotoInterval(_ request: DronecodeSdk_Rpc_Camera_StopPhotoIntervalRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopPhotoIntervalResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopPhotoIntervalCall {
     fatalError("not implemented")
   }
 
   var startVideoRequests: [DronecodeSdk_Rpc_Camera_StartVideoRequest] = []
   var startVideoResponses: [DronecodeSdk_Rpc_Camera_StartVideoResponse] = []
-  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse {
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoResponse {
     startVideoRequests.append(request)
     defer { startVideoResponses.removeFirst() }
     return startVideoResponses.first!
   }
-  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall {
+  func startVideo(_ request: DronecodeSdk_Rpc_Camera_StartVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoCall {
     fatalError("not implemented")
   }
 
   var stopVideoRequests: [DronecodeSdk_Rpc_Camera_StopVideoRequest] = []
   var stopVideoResponses: [DronecodeSdk_Rpc_Camera_StopVideoResponse] = []
-  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse {
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoResponse {
     stopVideoRequests.append(request)
     defer { stopVideoResponses.removeFirst() }
     return stopVideoResponses.first!
   }
-  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall {
+  func stopVideo(_ request: DronecodeSdk_Rpc_Camera_StopVideoRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoCall {
     fatalError("not implemented")
   }
 
   var startVideoStreamingRequests: [DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest] = []
   var startVideoStreamingResponses: [DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse] = []
-  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse {
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse {
     startVideoStreamingRequests.append(request)
     defer { startVideoStreamingResponses.removeFirst() }
     return startVideoStreamingResponses.first!
   }
-  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall {
+  func startVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StartVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StartVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStartVideoStreamingCall {
     fatalError("not implemented")
   }
 
   var stopVideoStreamingRequests: [DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest] = []
   var stopVideoStreamingResponses: [DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse] = []
-  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse {
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse {
     stopVideoStreamingRequests.append(request)
     defer { stopVideoStreamingResponses.removeFirst() }
     return stopVideoStreamingResponses.first!
   }
-  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall {
+  func stopVideoStreaming(_ request: DronecodeSdk_Rpc_Camera_StopVideoStreamingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_StopVideoStreamingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceStopVideoStreamingCall {
     fatalError("not implemented")
   }
 
   var setModeRequests: [DronecodeSdk_Rpc_Camera_SetModeRequest] = []
   var setModeResponses: [DronecodeSdk_Rpc_Camera_SetModeResponse] = []
-  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse {
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetModeResponse {
     setModeRequests.append(request)
     defer { setModeResponses.removeFirst() }
     return setModeResponses.first!
   }
-  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall {
+  func setMode(_ request: DronecodeSdk_Rpc_Camera_SetModeRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetModeResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetModeCall {
     fatalError("not implemented")
   }
 
   var subscribeModeRequests: [DronecodeSdk_Rpc_Camera_SubscribeModeRequest] = []
   var subscribeModeCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall] = []
-  func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall {
+  func subscribeMode(_ request: DronecodeSdk_Rpc_Camera_SubscribeModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeModeCall {
     subscribeModeRequests.append(request)
     defer { subscribeModeCalls.removeFirst() }
     return subscribeModeCalls.first!
@@ -550,18 +673,18 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var setVideoStreamSettingsRequests: [DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest] = []
   var setVideoStreamSettingsResponses: [DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse] = []
-  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse {
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse {
     setVideoStreamSettingsRequests.append(request)
     defer { setVideoStreamSettingsResponses.removeFirst() }
     return setVideoStreamSettingsResponses.first!
   }
-  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall {
+  func setVideoStreamSettings(_ request: DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetVideoStreamSettingsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetVideoStreamSettingsCall {
     fatalError("not implemented")
   }
 
   var subscribeVideoStreamInfoRequests: [DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest] = []
   var subscribeVideoStreamInfoCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall] = []
-  func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall {
+  func subscribeVideoStreamInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeVideoStreamInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeVideoStreamInfoCall {
     subscribeVideoStreamInfoRequests.append(request)
     defer { subscribeVideoStreamInfoCalls.removeFirst() }
     return subscribeVideoStreamInfoCalls.first!
@@ -569,7 +692,7 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var subscribeCaptureInfoRequests: [DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest] = []
   var subscribeCaptureInfoCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall] = []
-  func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall {
+  func subscribeCaptureInfo(_ request: DronecodeSdk_Rpc_Camera_SubscribeCaptureInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCaptureInfoCall {
     subscribeCaptureInfoRequests.append(request)
     defer { subscribeCaptureInfoCalls.removeFirst() }
     return subscribeCaptureInfoCalls.first!
@@ -577,7 +700,7 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var subscribeCameraStatusRequests: [DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest] = []
   var subscribeCameraStatusCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall] = []
-  func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall {
+  func subscribeCameraStatus(_ request: DronecodeSdk_Rpc_Camera_SubscribeCameraStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCameraStatusCall {
     subscribeCameraStatusRequests.append(request)
     defer { subscribeCameraStatusCalls.removeFirst() }
     return subscribeCameraStatusCalls.first!
@@ -585,7 +708,7 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var subscribeCurrentSettingsRequests: [DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest] = []
   var subscribeCurrentSettingsCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall] = []
-  func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall {
+  func subscribeCurrentSettings(_ request: DronecodeSdk_Rpc_Camera_SubscribeCurrentSettingsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribeCurrentSettingsCall {
     subscribeCurrentSettingsRequests.append(request)
     defer { subscribeCurrentSettingsCalls.removeFirst() }
     return subscribeCurrentSettingsCalls.first!
@@ -593,7 +716,7 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var subscribePossibleSettingOptionsRequests: [DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest] = []
   var subscribePossibleSettingOptionsCalls: [DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall] = []
-  func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall {
+  func subscribePossibleSettingOptions(_ request: DronecodeSdk_Rpc_Camera_SubscribePossibleSettingOptionsRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSubscribePossibleSettingOptionsCall {
     subscribePossibleSettingOptionsRequests.append(request)
     defer { subscribePossibleSettingOptionsCalls.removeFirst() }
     return subscribePossibleSettingOptionsCalls.first!
@@ -601,12 +724,12 @@ class DronecodeSdk_Rpc_Camera_CameraServiceServiceTestStub: ServiceClientTestStu
 
   var setSettingRequests: [DronecodeSdk_Rpc_Camera_SetSettingRequest] = []
   var setSettingResponses: [DronecodeSdk_Rpc_Camera_SetSettingResponse] = []
-  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse {
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Camera_SetSettingResponse {
     setSettingRequests.append(request)
     defer { setSettingResponses.removeFirst() }
     return setSettingResponses.first!
   }
-  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall {
+  func setSetting(_ request: DronecodeSdk_Rpc_Camera_SetSettingRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Camera_SetSettingResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Camera_CameraServiceSetSettingCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/core.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/core.grpc.swift
@@ -57,12 +57,29 @@ internal protocol DronecodeSdk_Rpc_Core_CoreServiceService: ServiceClient {
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall
+  func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall
 
   /// Synchronous. Unary.
-  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse
   /// Asynchronous. Unary.
-  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Core_CoreServiceService {
+  /// Asynchronous. Server-streaming.
+  func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall {
+    return try self.subscribeConnectionState(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse {
+    return try self.listRunningPlugins(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall {
+    return try self.listRunningPlugins(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
@@ -70,20 +87,20 @@ internal final class DronecodeSdk_Rpc_Core_CoreServiceServiceClient: ServiceClie
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall {
+  internal func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall {
     return try DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse {
+  internal func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse {
     return try DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall {
+  internal func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall {
     return try DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -91,7 +108,7 @@ internal final class DronecodeSdk_Rpc_Core_CoreServiceServiceClient: ServiceClie
 class DronecodeSdk_Rpc_Core_CoreServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Core_CoreServiceService {
   var subscribeConnectionStateRequests: [DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest] = []
   var subscribeConnectionStateCalls: [DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall] = []
-  func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall {
+  func subscribeConnectionState(_ request: DronecodeSdk_Rpc_Core_SubscribeConnectionStateRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Core_CoreServiceSubscribeConnectionStateCall {
     subscribeConnectionStateRequests.append(request)
     defer { subscribeConnectionStateCalls.removeFirst() }
     return subscribeConnectionStateCalls.first!
@@ -99,12 +116,12 @@ class DronecodeSdk_Rpc_Core_CoreServiceServiceTestStub: ServiceClientTestStubBas
 
   var listRunningPluginsRequests: [DronecodeSdk_Rpc_Core_ListRunningPluginsRequest] = []
   var listRunningPluginsResponses: [DronecodeSdk_Rpc_Core_ListRunningPluginsResponse] = []
-  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse {
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Core_ListRunningPluginsResponse {
     listRunningPluginsRequests.append(request)
     defer { listRunningPluginsResponses.removeFirst() }
     return listRunningPluginsResponses.first!
   }
-  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall {
+  func listRunningPlugins(_ request: DronecodeSdk_Rpc_Core_ListRunningPluginsRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Core_ListRunningPluginsResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Core_CoreServiceListRunningPluginsCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/info.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/info.grpc.swift
@@ -35,22 +35,34 @@ fileprivate final class DronecodeSdk_Rpc_Info_InfoServiceGetVersionCallBase: Cli
 /// Instantiate DronecodeSdk_Rpc_Info_InfoServiceServiceClient, then call methods of this protocol to make API calls.
 internal protocol DronecodeSdk_Rpc_Info_InfoServiceService: ServiceClient {
   /// Synchronous. Unary.
-  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse
   /// Asynchronous. Unary.
-  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Info_InfoServiceService {
+  /// Synchronous. Unary.
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse {
+    return try self.getVersion(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall {
+    return try self.getVersion(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
 internal final class DronecodeSdk_Rpc_Info_InfoServiceServiceClient: ServiceClientBase, DronecodeSdk_Rpc_Info_InfoServiceService {
   /// Synchronous. Unary.
-  internal func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse {
+  internal func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse {
     return try DronecodeSdk_Rpc_Info_InfoServiceGetVersionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall {
+  internal func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall {
     return try DronecodeSdk_Rpc_Info_InfoServiceGetVersionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -58,12 +70,12 @@ internal final class DronecodeSdk_Rpc_Info_InfoServiceServiceClient: ServiceClie
 class DronecodeSdk_Rpc_Info_InfoServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Info_InfoServiceService {
   var getVersionRequests: [DronecodeSdk_Rpc_Info_GetVersionRequest] = []
   var getVersionResponses: [DronecodeSdk_Rpc_Info_GetVersionResponse] = []
-  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse {
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Info_GetVersionResponse {
     getVersionRequests.append(request)
     defer { getVersionResponses.removeFirst() }
     return getVersionResponses.first!
   }
-  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall {
+  func getVersion(_ request: DronecodeSdk_Rpc_Info_GetVersionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Info_GetVersionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Info_InfoServiceGetVersionCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/mission.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/mission.grpc.swift
@@ -109,179 +109,277 @@ fileprivate final class DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunch
 /// Instantiate DronecodeSdk_Rpc_Mission_MissionServiceServiceClient, then call methods of this protocol to make API calls.
 internal protocol DronecodeSdk_Rpc_Mission_MissionServiceService: ServiceClient {
   /// Synchronous. Unary.
-  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse
   /// Asynchronous. Unary.
-  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall
 
   /// Synchronous. Unary.
-  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse
   /// Asynchronous. Unary.
-  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall
 
   /// Synchronous. Unary.
-  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse
   /// Asynchronous. Unary.
-  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall
 
   /// Synchronous. Unary.
-  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse
   /// Asynchronous. Unary.
-  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall
 
   /// Synchronous. Unary.
-  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse
   /// Asynchronous. Unary.
-  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall
 
   /// Synchronous. Unary.
-  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse
   /// Asynchronous. Unary.
-  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall
 
   /// Synchronous. Unary.
-  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse
   /// Asynchronous. Unary.
-  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall
 
   /// Synchronous. Unary.
-  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse
   /// Asynchronous. Unary.
-  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall
+  func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall
 
   /// Synchronous. Unary.
-  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse
   /// Asynchronous. Unary.
-  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall
 
   /// Synchronous. Unary.
-  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse
   /// Asynchronous. Unary.
-  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Mission_MissionServiceService {
+  /// Synchronous. Unary.
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse {
+    return try self.uploadMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall {
+    return try self.uploadMission(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse {
+    return try self.cancelMissionUpload(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall {
+    return try self.cancelMissionUpload(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse {
+    return try self.downloadMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall {
+    return try self.downloadMission(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse {
+    return try self.cancelMissionDownload(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall {
+    return try self.cancelMissionDownload(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse {
+    return try self.startMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall {
+    return try self.startMission(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse {
+    return try self.pauseMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall {
+    return try self.pauseMission(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse {
+    return try self.setCurrentMissionItemIndex(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall {
+    return try self.setCurrentMissionItemIndex(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse {
+    return try self.isMissionFinished(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall {
+    return try self.isMissionFinished(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall {
+    return try self.subscribeMissionProgress(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse {
+    return try self.getReturnToLaunchAfterMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall {
+    return try self.getReturnToLaunchAfterMission(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Synchronous. Unary.
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse {
+    return try self.setReturnToLaunchAfterMission(request, metadata: self.metadata)
+  }
+  /// Asynchronous. Unary.
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall {
+    return try self.setReturnToLaunchAfterMission(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
 internal final class DronecodeSdk_Rpc_Mission_MissionServiceServiceClient: ServiceClientBase, DronecodeSdk_Rpc_Mission_MissionServiceService {
   /// Synchronous. Unary.
-  internal func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse {
+  internal func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall {
+  internal func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse {
+  internal func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall {
+  internal func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse {
+  internal func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall {
+  internal func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse {
+  internal func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall {
+  internal func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse {
+  internal func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall {
+  internal func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse {
+  internal func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall {
+  internal func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse {
+  internal func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall {
+  internal func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse {
+  internal func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall {
+  internal func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall {
+  internal func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse {
+  internal func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall {
+  internal func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse {
+  internal func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse {
     return try DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCallBase(channel)
-      .run(request: request, metadata: metadata)
+      .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
-  internal func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall {
+  internal func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall {
     return try DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -289,95 +387,95 @@ internal final class DronecodeSdk_Rpc_Mission_MissionServiceServiceClient: Servi
 class DronecodeSdk_Rpc_Mission_MissionServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Mission_MissionServiceService {
   var uploadMissionRequests: [DronecodeSdk_Rpc_Mission_UploadMissionRequest] = []
   var uploadMissionResponses: [DronecodeSdk_Rpc_Mission_UploadMissionResponse] = []
-  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse {
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_UploadMissionResponse {
     uploadMissionRequests.append(request)
     defer { uploadMissionResponses.removeFirst() }
     return uploadMissionResponses.first!
   }
-  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall {
+  func uploadMission(_ request: DronecodeSdk_Rpc_Mission_UploadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_UploadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceUploadMissionCall {
     fatalError("not implemented")
   }
 
   var cancelMissionUploadRequests: [DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest] = []
   var cancelMissionUploadResponses: [DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse] = []
-  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse {
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse {
     cancelMissionUploadRequests.append(request)
     defer { cancelMissionUploadResponses.removeFirst() }
     return cancelMissionUploadResponses.first!
   }
-  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall {
+  func cancelMissionUpload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionUploadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionUploadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionUploadCall {
     fatalError("not implemented")
   }
 
   var downloadMissionRequests: [DronecodeSdk_Rpc_Mission_DownloadMissionRequest] = []
   var downloadMissionResponses: [DronecodeSdk_Rpc_Mission_DownloadMissionResponse] = []
-  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse {
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_DownloadMissionResponse {
     downloadMissionRequests.append(request)
     defer { downloadMissionResponses.removeFirst() }
     return downloadMissionResponses.first!
   }
-  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall {
+  func downloadMission(_ request: DronecodeSdk_Rpc_Mission_DownloadMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_DownloadMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceDownloadMissionCall {
     fatalError("not implemented")
   }
 
   var cancelMissionDownloadRequests: [DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest] = []
   var cancelMissionDownloadResponses: [DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse] = []
-  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse {
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse {
     cancelMissionDownloadRequests.append(request)
     defer { cancelMissionDownloadResponses.removeFirst() }
     return cancelMissionDownloadResponses.first!
   }
-  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall {
+  func cancelMissionDownload(_ request: DronecodeSdk_Rpc_Mission_CancelMissionDownloadRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_CancelMissionDownloadResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceCancelMissionDownloadCall {
     fatalError("not implemented")
   }
 
   var startMissionRequests: [DronecodeSdk_Rpc_Mission_StartMissionRequest] = []
   var startMissionResponses: [DronecodeSdk_Rpc_Mission_StartMissionResponse] = []
-  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse {
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_StartMissionResponse {
     startMissionRequests.append(request)
     defer { startMissionResponses.removeFirst() }
     return startMissionResponses.first!
   }
-  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall {
+  func startMission(_ request: DronecodeSdk_Rpc_Mission_StartMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_StartMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceStartMissionCall {
     fatalError("not implemented")
   }
 
   var pauseMissionRequests: [DronecodeSdk_Rpc_Mission_PauseMissionRequest] = []
   var pauseMissionResponses: [DronecodeSdk_Rpc_Mission_PauseMissionResponse] = []
-  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse {
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_PauseMissionResponse {
     pauseMissionRequests.append(request)
     defer { pauseMissionResponses.removeFirst() }
     return pauseMissionResponses.first!
   }
-  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall {
+  func pauseMission(_ request: DronecodeSdk_Rpc_Mission_PauseMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_PauseMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServicePauseMissionCall {
     fatalError("not implemented")
   }
 
   var setCurrentMissionItemIndexRequests: [DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest] = []
   var setCurrentMissionItemIndexResponses: [DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse] = []
-  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse {
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse {
     setCurrentMissionItemIndexRequests.append(request)
     defer { setCurrentMissionItemIndexResponses.removeFirst() }
     return setCurrentMissionItemIndexResponses.first!
   }
-  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall {
+  func setCurrentMissionItemIndex(_ request: DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetCurrentMissionItemIndexResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetCurrentMissionItemIndexCall {
     fatalError("not implemented")
   }
 
   var isMissionFinishedRequests: [DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest] = []
   var isMissionFinishedResponses: [DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse] = []
-  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse {
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse {
     isMissionFinishedRequests.append(request)
     defer { isMissionFinishedResponses.removeFirst() }
     return isMissionFinishedResponses.first!
   }
-  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall {
+  func isMissionFinished(_ request: DronecodeSdk_Rpc_Mission_IsMissionFinishedRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_IsMissionFinishedResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceIsMissionFinishedCall {
     fatalError("not implemented")
   }
 
   var subscribeMissionProgressRequests: [DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest] = []
   var subscribeMissionProgressCalls: [DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall] = []
-  func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall {
+  func subscribeMissionProgress(_ request: DronecodeSdk_Rpc_Mission_SubscribeMissionProgressRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSubscribeMissionProgressCall {
     subscribeMissionProgressRequests.append(request)
     defer { subscribeMissionProgressCalls.removeFirst() }
     return subscribeMissionProgressCalls.first!
@@ -385,23 +483,23 @@ class DronecodeSdk_Rpc_Mission_MissionServiceServiceTestStub: ServiceClientTestS
 
   var getReturnToLaunchAfterMissionRequests: [DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest] = []
   var getReturnToLaunchAfterMissionResponses: [DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse] = []
-  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse {
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse {
     getReturnToLaunchAfterMissionRequests.append(request)
     defer { getReturnToLaunchAfterMissionResponses.removeFirst() }
     return getReturnToLaunchAfterMissionResponses.first!
   }
-  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall {
+  func getReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_GetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceGetReturnToLaunchAfterMissionCall {
     fatalError("not implemented")
   }
 
   var setReturnToLaunchAfterMissionRequests: [DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest] = []
   var setReturnToLaunchAfterMissionResponses: [DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse] = []
-  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse {
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata) throws -> DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse {
     setReturnToLaunchAfterMissionRequests.append(request)
     defer { setReturnToLaunchAfterMissionResponses.removeFirst() }
     return setReturnToLaunchAfterMissionResponses.first!
   }
-  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall {
+  func setReturnToLaunchAfterMission(_ request: DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionRequest, metadata customMetadata: Metadata, completion: @escaping (DronecodeSdk_Rpc_Mission_SetReturnToLaunchAfterMissionResponse?, CallResult) -> Void) throws -> DronecodeSdk_Rpc_Mission_MissionServiceSetReturnToLaunchAfterMissionCall {
     fatalError("not implemented")
   }
 

--- a/Sources/Dronecode-SDK-Swift/Generated/telemetry.grpc.swift
+++ b/Sources/Dronecode-SDK-Swift/Generated/telemetry.grpc.swift
@@ -311,72 +311,145 @@ internal protocol DronecodeSdk_Rpc_Telemetry_TelemetryServiceService: ServiceCli
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall
+  func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall
+  func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall
+  func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall
+  func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall
+  func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall
+  func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall
+  func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall
+  func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall
+  func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall
+  func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall
+  func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall
+  func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall
+  func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall
+  func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall
+
+}
+
+internal extension DronecodeSdk_Rpc_Telemetry_TelemetryServiceService {
+  /// Asynchronous. Server-streaming.
+  func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall {
+    return try self.subscribePosition(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall {
+    return try self.subscribeHome(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall {
+    return try self.subscribeInAir(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall {
+    return try self.subscribeArmed(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall {
+    return try self.subscribeAttitudeQuaternion(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall {
+    return try self.subscribeAttitudeEuler(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall {
+    return try self.subscribeCameraAttitudeQuaternion(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall {
+    return try self.subscribeCameraAttitudeEuler(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall {
+    return try self.subscribeGroundSpeedNed(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall {
+    return try self.subscribeGpsInfo(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall {
+    return try self.subscribeBattery(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall {
+    return try self.subscribeFlightMode(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall {
+    return try self.subscribeHealth(request, metadata: self.metadata, completion: completion)
+  }
+
+  /// Asynchronous. Server-streaming.
+  func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall {
+    return try self.subscribeRcStatus(request, metadata: self.metadata, completion: completion)
+  }
 
 }
 
@@ -384,113 +457,113 @@ internal final class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceClient: S
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall {
+  internal func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall {
+  internal func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall {
+  internal func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall {
+  internal func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall {
+  internal func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall {
+  internal func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall {
+  internal func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall {
+  internal func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall {
+  internal func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall {
+  internal func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall {
+  internal func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall {
+  internal func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall {
+  internal func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  internal func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall {
+  internal func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall {
     return try DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCallBase(channel)
-      .start(request: request, metadata: metadata, completion: completion)
+      .start(request: request, metadata: customMetadata, completion: completion)
   }
 
 }
@@ -498,7 +571,7 @@ internal final class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceClient: S
 class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientTestStubBase, DronecodeSdk_Rpc_Telemetry_TelemetryServiceService {
   var subscribePositionRequests: [DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest] = []
   var subscribePositionCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall] = []
-  func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall {
+  func subscribePosition(_ request: DronecodeSdk_Rpc_Telemetry_SubscribePositionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribePositionCall {
     subscribePositionRequests.append(request)
     defer { subscribePositionCalls.removeFirst() }
     return subscribePositionCalls.first!
@@ -506,7 +579,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeHomeRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest] = []
   var subscribeHomeCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall] = []
-  func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall {
+  func subscribeHome(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHomeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHomeCall {
     subscribeHomeRequests.append(request)
     defer { subscribeHomeCalls.removeFirst() }
     return subscribeHomeCalls.first!
@@ -514,7 +587,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeInAirRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest] = []
   var subscribeInAirCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall] = []
-  func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall {
+  func subscribeInAir(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeInAirRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeInAirCall {
     subscribeInAirRequests.append(request)
     defer { subscribeInAirCalls.removeFirst() }
     return subscribeInAirCalls.first!
@@ -522,7 +595,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeArmedRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest] = []
   var subscribeArmedCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall] = []
-  func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall {
+  func subscribeArmed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeArmedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeArmedCall {
     subscribeArmedRequests.append(request)
     defer { subscribeArmedCalls.removeFirst() }
     return subscribeArmedCalls.first!
@@ -530,7 +603,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeAttitudeQuaternionRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest] = []
   var subscribeAttitudeQuaternionCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall] = []
-  func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall {
+  func subscribeAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeQuaternionCall {
     subscribeAttitudeQuaternionRequests.append(request)
     defer { subscribeAttitudeQuaternionCalls.removeFirst() }
     return subscribeAttitudeQuaternionCalls.first!
@@ -538,7 +611,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeAttitudeEulerRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest] = []
   var subscribeAttitudeEulerCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall] = []
-  func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall {
+  func subscribeAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeAttitudeEulerCall {
     subscribeAttitudeEulerRequests.append(request)
     defer { subscribeAttitudeEulerCalls.removeFirst() }
     return subscribeAttitudeEulerCalls.first!
@@ -546,7 +619,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeCameraAttitudeQuaternionRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest] = []
   var subscribeCameraAttitudeQuaternionCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall] = []
-  func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall {
+  func subscribeCameraAttitudeQuaternion(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeQuaternionRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeQuaternionCall {
     subscribeCameraAttitudeQuaternionRequests.append(request)
     defer { subscribeCameraAttitudeQuaternionCalls.removeFirst() }
     return subscribeCameraAttitudeQuaternionCalls.first!
@@ -554,7 +627,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeCameraAttitudeEulerRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest] = []
   var subscribeCameraAttitudeEulerCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall] = []
-  func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall {
+  func subscribeCameraAttitudeEuler(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeCameraAttitudeEulerRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeCameraAttitudeEulerCall {
     subscribeCameraAttitudeEulerRequests.append(request)
     defer { subscribeCameraAttitudeEulerCalls.removeFirst() }
     return subscribeCameraAttitudeEulerCalls.first!
@@ -562,7 +635,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeGroundSpeedNedRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest] = []
   var subscribeGroundSpeedNedCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall] = []
-  func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall {
+  func subscribeGroundSpeedNed(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGroundSpeedNedRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGroundSpeedNedCall {
     subscribeGroundSpeedNedRequests.append(request)
     defer { subscribeGroundSpeedNedCalls.removeFirst() }
     return subscribeGroundSpeedNedCalls.first!
@@ -570,7 +643,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeGpsInfoRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest] = []
   var subscribeGpsInfoCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall] = []
-  func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall {
+  func subscribeGpsInfo(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeGpsInfoRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeGpsInfoCall {
     subscribeGpsInfoRequests.append(request)
     defer { subscribeGpsInfoCalls.removeFirst() }
     return subscribeGpsInfoCalls.first!
@@ -578,7 +651,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeBatteryRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest] = []
   var subscribeBatteryCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall] = []
-  func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall {
+  func subscribeBattery(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeBatteryRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeBatteryCall {
     subscribeBatteryRequests.append(request)
     defer { subscribeBatteryCalls.removeFirst() }
     return subscribeBatteryCalls.first!
@@ -586,7 +659,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeFlightModeRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest] = []
   var subscribeFlightModeCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall] = []
-  func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall {
+  func subscribeFlightMode(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeFlightModeRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeFlightModeCall {
     subscribeFlightModeRequests.append(request)
     defer { subscribeFlightModeCalls.removeFirst() }
     return subscribeFlightModeCalls.first!
@@ -594,7 +667,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeHealthRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest] = []
   var subscribeHealthCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall] = []
-  func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall {
+  func subscribeHealth(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeHealthRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeHealthCall {
     subscribeHealthRequests.append(request)
     defer { subscribeHealthCalls.removeFirst() }
     return subscribeHealthCalls.first!
@@ -602,7 +675,7 @@ class DronecodeSdk_Rpc_Telemetry_TelemetryServiceServiceTestStub: ServiceClientT
 
   var subscribeRcStatusRequests: [DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest] = []
   var subscribeRcStatusCalls: [DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall] = []
-  func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall {
+  func subscribeRcStatus(_ request: DronecodeSdk_Rpc_Telemetry_SubscribeRcStatusRequest, metadata customMetadata: Metadata, completion: ((CallResult) -> Void)?) throws -> DronecodeSdk_Rpc_Telemetry_TelemetryServiceSubscribeRcStatusCall {
     subscribeRcStatusRequests.append(request)
     defer { subscribeRcStatusCalls.removeFirst() }
     return subscribeRcStatusCalls.first!

--- a/tools/generate_from_protos.bash
+++ b/tools/generate_from_protos.bash
@@ -37,7 +37,7 @@ if [ ! -d ${TMP_DIR}/grpc-swift ]; then
     echo "--- Cloning grpc-swift"
     echo ""
 
-    git -C ${TMP_DIR} clone https://github.com/3drobotics/grpc-swift
+    git -C ${TMP_DIR} clone -b 0.8.0 https://github.com/grpc/grpc-swift
 fi
 
 cd ${TMP_DIR}/grpc-swift && make


### PR DESCRIPTION
I believe that the latest grpc-swift release (0.8.0) includes @byuarus' fix, meaning that we can go back to using upstream instead of the 3drobotics fork.

It is apparently working for me, but I would be glad if you guys could try to `carthage update --platform ios` on your side. Somehow I had to `rm -rf Carthage/` for it to work on my end, I am not sure why.