### PR TITLE
grpc-swift 0.8.2 apparently broke the build.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "grpc/grpc-swift" ~> 0.8.0
-github "ReactiveX/RxSwift" ~> 4.0
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" ~> 0.15.0
+github "grpc/grpc-swift" == 0.8.1
+github "ReactiveX/RxSwift" == 4.5.0
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.16.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.15.0"
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.16.0"
 github "ReactiveX/RxSwift" "4.5.0"
 github "grpc/grpc-swift" "0.8.1"

--- a/tools/generate_from_protos.bash
+++ b/tools/generate_from_protos.bash
@@ -37,7 +37,7 @@ if [ ! -d ${TMP_DIR}/grpc-swift ]; then
     echo "--- Cloning grpc-swift"
     echo ""
 
-    git -C ${TMP_DIR} clone -b 0.8.0 https://github.com/grpc/grpc-swift
+    git -C ${TMP_DIR} clone -b 0.8.1 https://github.com/grpc/grpc-swift
 fi
 
 cd ${TMP_DIR}/grpc-swift && make


### PR DESCRIPTION
Using `~>` for Carthage dependencies was a mistake, and that broke our build. Let's stick to `==` now.

Resolves #120, replaces #122.

@douglaswsilva, @byuarus: FYI