### PR TITLE
Correcting instructions error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ carthage build --platform ios --no-skip-current --verbose
 
 Then you can open `Dronecode-SDK-Swift.xcodeproj` in XCode and build it, or do:
 ```
-xcodebuild -scheme Dronecode-SDK-Swift
+xcodebuild -scheme Dronecode_SDK_Swift
 ```
 
 ### Generate docs


### PR DESCRIPTION
The scheme defined in the project is Dronecode_SDK_Swift, not Dronecode-SDK-Swift.